### PR TITLE
hotfix: invalid string test needs to handle all OS

### DIFF
--- a/tests/DirfileDB.test.ts
+++ b/tests/DirfileDB.test.ts
@@ -20,7 +20,8 @@ test("constructor", {
         }),
 
         test("fails on invalid dir string", () => {
-            assert.throws(() => new DirfileDB({rootDir: " 11 1f248914f@#$%^&*'z  . . ."}))
+            const invalidStr = "CON:/" //invalid directory string for Windows and Linux/Unix
+            assert.throws(() => new DirfileDB({rootDir: invalidStr})) 
         }),
 
         test("should persist metadata when connecting to existing db", () => {


### PR DESCRIPTION
constructor invalid string test was failing in GitHub Actions, assuming due to running in linux adjusting string to be more invalid for all OS's